### PR TITLE
Fix: display req parameter

### DIFF
--- a/editor/animation/init.js
+++ b/editor/animation/init.js
@@ -77,7 +77,7 @@ requirejs(['ext_editor_io', 'jquery_190'],
 
             
 
-            return els + start_watching + end_watching + operating;
+            return els + start_watching + end_watching + operating + req;
         }
         io.start();
     }


### PR DESCRIPTION
Two things:
* `req` parameter is currently not displayed, this pull request fixes that, an easy fix.
* New issue: `var is_py = this.getLanguage() == "python"` is not a valid way to test if it's "python" since I got javascript display on "py.checkio.org". But I don't know what is the valid way so I'm not gonna fix that right now.